### PR TITLE
pass the right parameters to unzip

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ fi
 mkdir -p ${WORKSPACE}/${NAME}-${VERSION}
 # the name of the tar upack dir is some wierd combination of underscores and numbers, so we'll just redefined where
 # the code gets unpacked
-unzip ${SRC_DIR}/${SOURCE_FILE} -d ${WORKSPACE}/${NAME}-${VERSION}
+unzip -u ${SRC_DIR}/${SOURCE_FILE} -d ${WORKSPACE}/${NAME}-${VERSION}
 cd ${WORKSPACE}/${NAME}-${VERSION}
 # Check if REPAST libs are available.
 echo "[build.sh] - Listing '${WORKSPACE}/${NAME}-${VERSION}' folder ..."

--- a/check-build.sh
+++ b/check-build.sh
@@ -56,8 +56,8 @@ setenv REPAST_HOME                /apprepo/$::env(SITE)/$::env(OS)/$::env(ARCH)/
 prepend-path LD_LIBRARY_PATH    $::env(CLASSPATH)
 MODULE_FILE
 ) > modules/${VERSION}
-mkdir -p ${LIBRARIES_MODULES}/${NAME}/${VERSION}
-cp modules/${VERSION} ${LIBRARIES_MODULES}/${NAME}/${VERSION}
+mkdir -p ${LIBRARIES_MODULES}/${NAME}
+cp modules/${VERSION} ${LIBRARIES_MODULES}/${NAME}
 
 echo "[check-build.sh] - Checking REPAST module"
 module add $NAME/$VERSION


### PR DESCRIPTION
When the unzip runs, there's a dialog with the user  which says 

```
Getting REPAST Libraries from http://grid.ct.infn.it/csgf/binaries/repast/2.1.0
Archive:  /repo/src/repast/2.1.0/repast_2.1.0_linux-x64.zip
replace /var/lib/jenkins/workspace/repast-deploy/ARCH/x86_64/JAVA_VERSION/7u80/NAME/repast/OS/sl6/SITE/generic/VERSION/2.1.0/repast-2.1.0/plugins/libs.bsf_2.1.0/lib/bsf.jar? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
(EOF or read error, treating as "[N]one" ...)
```

the lack of input fails the build.

Passing -u will update all files automatically. : 
`-u  update files, create if necessary`
